### PR TITLE
feat: Adds a dry run to cli and server operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ The payload is expected to be JSON with the following fields:
   to limit cleaning only on the tags with begining with is `dev`. The default
   is no filtering. The regular expression is parsed according to the [Go regexp package syntax](https://golang.org/pkg/regexp/syntax/).
 
+- `dry_run` - If true don't delete anything and output what would be deleted (assuming no errors would occuring delete api call).
+
 ## Running locally
 
 In addition to the server, you can also run GCR Cleaner locally for one-off tasks using `cmd/gcr-cleaner-cli`:

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -49,12 +49,11 @@ func NewCleaner(auther gcrauthn.Authenticator, c int) (*Cleaner, error) {
 
 // Clean deletes old images from GCR that are (un)tagged and older than "since" and
 // higher than the "keep" amount.
-func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int, tagFilterRegexp *regexp.Regexp) ([]string, error) {
+func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int, tagFilterRegexp *regexp.Regexp, dryRun bool) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)
 	}
-
 	tags, err := gcrgoogle.List(gcrrepo, gcrgoogle.WithAuth(c.auther))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tags for repo %s: %w", repo, err)
@@ -90,7 +89,7 @@ func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int
 			// Deletes all tags before deleting the image
 			for _, tag := range m.Info.Tags {
 				tagged := gcrrepo.Tag(tag)
-				if err := c.deleteOne(tagged); err != nil {
+				if err := c.deleteOne(tagged, dryRun); err != nil {
 					return nil, fmt.Errorf("failed to delete %s: %w", tagged, err)
 				}
 			}
@@ -106,7 +105,7 @@ func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int
 				}
 				errsLock.RUnlock()
 
-				if err := c.deleteOne(ref); err != nil {
+				if err := c.deleteOne(ref, dryRun); err != nil {
 					cause := errors.Unwrap(err).Error()
 
 					errsLock.Lock()
@@ -152,7 +151,12 @@ type manifest struct {
 }
 
 // deleteOne deletes a single repo ref using the supplied auth.
-func (c *Cleaner) deleteOne(ref gcrname.Reference) error {
+func (c *Cleaner) deleteOne(ref gcrname.Reference, dryRun bool) error {
+	if dryRun {
+		fmt.Printf("dry delete: %s \n", ref)
+		return nil
+	}
+
 	if err := gcrremote.Delete(ref, gcrremote.WithAuth(c.auther)); err != nil {
 		return fmt.Errorf("failed to delete %s: %w", ref, err)
 	}

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -139,7 +139,7 @@ func (s *Server) clean(r io.ReadCloser) ([]string, int, error) {
 
 	log.Printf("deleting refs for %s since %s\n", repo, since)
 
-	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, tagFilterRegexp)
+	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, tagFilterRegexp, p.DryRun)
 	if err != nil {
 		return nil, 400, fmt.Errorf("failed to clean: %w", err)
 	}
@@ -183,6 +183,9 @@ type Payload struct {
 
 	// TagFilter is the tags pattern to be allowed removing
 	TagFilter string `json:"tag_filter"`
+
+	// DryRun is to enable a NOOP
+	DryRun bool `json:"dry_run"`
 }
 
 type pubsubMessage struct {


### PR DESCRIPTION
I think the `deleteOne` is probably the best place for this, this lets
all the code paths execute making it "accurate".

ref: #34